### PR TITLE
Support for labels in popups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.synctex.gz(busy)
 *.toc
 
+# VS Code
+.vscode
+
 # JetBrains IDE files
 .idea
 

--- a/CSS/AXM.css
+++ b/CSS/AXM.css
@@ -539,4 +539,14 @@ body {
     opacity:0.25;
 }
 
-
+span.AXMBadge {
+    display: inline-block;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 10rem;
+    font-size: 75%;
+    padding: 5px 10px;
+    margin: 0px 5px;
+  }

--- a/DOM.js
+++ b/DOM.js
@@ -205,8 +205,6 @@ define([
             return that;
         };
 
-
-
         /**
          * Returns a label element
          * @param {{}} args - see Module._Element

--- a/Panels/FlexTabber.js
+++ b/Panels/FlexTabber.js
@@ -518,8 +518,10 @@ define([
                     autoCenter: true,
                     canDock: true,
                     sizeX: 750,
-                    sizeY:570
+                    sizeY:570,
+                    labels: tabInfo.headerInfo.labels
                 });
+
                 popup.__originalFlexTabberId = tabId;
 
                 popup.setHeaderInfo(tabInfo.headerInfo);

--- a/Panels/FlexTabber.js
+++ b/Panels/FlexTabber.js
@@ -244,11 +244,11 @@ define([
                 }
 
                 $.each(PopupWindow.getActiveWindowList(), function(idx, popupWindow) {
-                    if (tabId == popupWindow.__originalFlexTabberId) {
+                    if (tabId === popupWindow.__originalFlexTabberId) {
+                        popupWindow.modifyLabels(settings.labels || {});
                         popupWindow.modifyTitle(newTitle1 + " " + newTitle2);
                     }
                 });
-
             };
 
 

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -105,6 +105,7 @@ define([
          * @param {boolean} settings.preventClose - if true, the user cannot close the popup
          * @param {boolean} settings.minSizeX - minimum X popup size
          * @param {boolean} settings.minSizeY - minimum Y popup size
+         * @param {Object} settings.labels - map with labels to be displayed
          * @returns {PopupWindow} - popup window class instance
          */
         Module.create = function(settings) {
@@ -133,6 +134,7 @@ define([
             window._isLogin = settings.isLogin||false;
             window.overflowAllowed = settings.overflowAllowed || false;
             window._listeners = [];
+            window._labels = settings.labels || {};
 
             window.setHeaderInfo = function(headerInfo) {
                 window._headerInfo = headerInfo;
@@ -268,7 +270,21 @@ define([
                             headerDiv.addElem(str);
                         }
                     }
-                    headerDiv.addElem('<div style="display: inline-block;margin-right:70px;overflow-x: hidden;text-overflow: ellipsis; vertical-align: middle" class="PopupHeaderTitleText">' + window._title + '</div>');
+
+                    let titleText = DOM.Div({parent: headerDiv});
+                    titleText.addCssClass("PopupHeaderTitleText")
+                        .addStyle("display", "inline-block")
+                        .addStyle("margin-right", "70px")
+                        .addStyle("overflow-x", "hidden")
+                        .addStyle("text-overflow", "ellipsis") 
+                        .addStyle("vertical-align", "middle")
+                        .addElem(window._title)
+
+                    // Add labels to popup header as "badges"
+                    Object.keys(window._labels)
+                        .map(k => window._labels[k])
+                        .map(label => DOM.Create("span").addCssClass(label.cssClass).addCssClass("AXMBadge").addElem(label.text))
+                        .forEach(badge => titleText.addElem(badge));
                 }
 
                 var transfer$Elem = null;

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -168,6 +168,10 @@ define([
                 window._$ElContainer.find('.PopupHeaderTitleText').html(newTitle);
             };
 
+            window.modifyLabels = function (labels) {
+                window._labels = labels;
+            };
+
             /**
              * Defines the root frame to be displayed in the popup (popup will be window style, containing frames and will be resizeable)
              * @param {AXM.Frame} iFrame
@@ -283,7 +287,7 @@ define([
                     // Add labels to popup header as "badges"
                     Object.keys(window._labels).forEach(function (k) {
                         let label = window._labels[k];
-                        DOM.Create("span", {parent: titleText}).addCssClass(label.cssClass).addCssClass("AXMBadge").addElem(label.text);
+                        DOM.Create("span", {parent: headerDiv}).addCssClass(label.cssClass).addCssClass("AXMBadge").addElem(label.text);
                     });
                 }
 

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -281,10 +281,10 @@ define([
                         .addElem(window._title)
 
                     // Add labels to popup header as "badges"
-                    Object.keys(window._labels)
-                        .map(k => window._labels[k])
-                        .map(label => DOM.Create("span").addCssClass(label.cssClass).addCssClass("AXMBadge").addElem(label.text))
-                        .forEach(badge => titleText.addElem(badge));
+                    Object.keys(window._labels).forEach(function (k) {
+                        let label = window._labels[k];
+                        DOM.Create("span", {parent: titleText}).addCssClass(label.cssClass).addCssClass("AXMBadge").addElem(label.text);
+                    });
                 }
 
                 var transfer$Elem = null;

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -170,6 +170,8 @@ define([
 
             window.modifyLabels = function (labels) {
                 window._labels = labels;
+                window._$ElContainer.find('.AXMPopupLabelsPlaceholder').html(
+                    window.labels.join(""))
             };
 
             /**
@@ -278,17 +280,19 @@ define([
                     let titleText = DOM.Div({parent: headerDiv});
                     titleText.addCssClass("PopupHeaderTitleText")
                         .addStyle("display", "inline-block")
-                        .addStyle("margin-right", "70px")
+                        .addStyle("margin-right", "20px")
                         .addStyle("overflow-x", "hidden")
                         .addStyle("text-overflow", "ellipsis") 
                         .addStyle("vertical-align", "middle")
                         .addElem(window._title)
 
+                    let labelsContainer = DOM.Create("span");
+                    labelsContainer.addCssClass("AXMPopupLabelsPlaceholder");
                     // Add labels to popup header as "badges"
-                    Object.keys(window._labels).forEach(function (k) {
-                        let label = window._labels[k];
-                        DOM.Create("span", {parent: headerDiv}).addCssClass(label.cssClass).addCssClass("AXMBadge").addElem(label.text);
+                    window.labels.forEach(function addBadge (badge) {
+                        labelsContainer.addElem(badge);
                     });
+                    headerDiv.addElem(labelsContainer);
                 }
 
                 var transfer$Elem = null;
@@ -410,6 +414,18 @@ define([
                     AXMUtils.reportBug("Popup is not yet started");
                 return window._$ElContainer;
             };
+
+            Object.defineProperty(window, 'labels', {
+                get: function getLabels () {
+                    return Object.keys(window._labels).map(function (k) {
+                        let label = window._labels[k];
+                        return DOM.Create("span")
+                            .addCssClass(label.cssClass)
+                            .addCssClass("AXMBadge")
+                            .addElem(label.text);
+                    });
+                }
+            });
 
             /**
              * Handles the html on key down event


### PR DESCRIPTION
[#1536: Frame flextabber labels are not shown if frame becomes a popup](https://github.com/Multiplicom/mastr_reporter/issues/1536)

Passes the frame's labels to the popup, i.e. same text and styling. Unlike the icon might suggest, it doesn't support a tooltip with the explanatory text like in the top bar.