### PR TITLE
Relative header positioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 *.toc
 
 # Development
-/node_modules
-/dist
+node_modules/
+dist/
+demo/
 
 # VS Code
 .vscode

--- a/CSS/AXM.css
+++ b/CSS/AXM.css
@@ -425,7 +425,7 @@ body {
     font-size: 44px;
     display: inline-block;
     padding-top:4px;
-    padding-right:16px;
+    padding-right:4px;
     vertical-align: top;
 }
 

--- a/CSS/AXM.css
+++ b/CSS/AXM.css
@@ -425,7 +425,7 @@ body {
     font-size: 44px;
     display: inline-block;
     padding-top:4px;
-    padding-right:4px;
+    padding-right:8px;
     vertical-align: top;
 }
 

--- a/CSS/AXMPopupWindow.css
+++ b/CSS/AXMPopupWindow.css
@@ -61,10 +61,16 @@
     cursor:pointer;
 }
 
+.SWXPopupWindowButtons {
+    display: inline-flex;
+    justify-content: flex-end;
+    margin-left: auto;
+}
+
 .SWXPopupWindowCloseBox {
-    position:absolute;
-    right:8px;
-    top:8px;
+    position: relative;
+    top: 8px;
+    padding-left: 4px;    
     cursor:pointer;
     font-size: 22px;
     color: white;
@@ -81,7 +87,6 @@
 .SWXPopupWindowHelpBox {
     font-size: 22px;
     position: relative;
-    margin-left: auto;
 }
 
 .AXMBadge {
@@ -98,9 +103,9 @@
 }
 
 .SWXPopupWindowDockBox {
-    position:absolute;
-    right:32px;
-    top:8px;
+    position: relative;
+    top: 8px;
+    padding-left: 4px;
     cursor:pointer;
     font-size: 22px;
     color: white;

--- a/CSS/AXMPopupWindow.css
+++ b/CSS/AXMPopupWindow.css
@@ -41,6 +41,7 @@
     padding-left:8px;
     padding-right:8px;
     box-sizing: border-box;
+    display: inline-flex;
     /*border-top-left-radius:5px;*/
     /*border-top-right-radius:5px;*/
 
@@ -60,7 +61,7 @@
     cursor:pointer;
 }
 
-.SWXPopupWindowCloseBox, .SWXPopupWindowHelpBox {
+.SWXPopupWindowCloseBox {
     position:absolute;
     right:8px;
     top:8px;
@@ -78,10 +79,14 @@
 }
 
 .SWXPopupWindowHelpBox {
-    right:35px;
-
+    font-size: 22px;
+    position: relative;
+    margin-left: auto;
 }
 
+.AXMBadge {
+    transform: translateY(50%);
+}
 
 .SWXPopupWindowCloseBox:hover, .SWXPopupWindowHelpBox:hover {
     opacity: 0.9;

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -276,6 +276,7 @@ define([
                         .addStyle("margin-right", "8px")
                         .addStyle("display", "inline-block")
                         .addStyle("overflow-x", "hidden")
+                        .addStyle("overflow-y", "hidden")
                         .addStyle("text-overflow", "ellipsis") 
                         .addStyle("vertical-align", "middle")
                         .addElem(window._title)
@@ -292,14 +293,26 @@ define([
                         headerDiv.addElem(labelsContainer);
                     }
 
+                    var windowButtons = DOM.Create("div");
+                    windowButtons.addCssClass("SWXPopupWindowButtons");
+
                     if (window._helpID){
-                        // headerDiv.addElem('<div class="SWXPopupWindowHelpBox" style="position: relative;"><i class="fa fa-question"></i></div>');
                         var help = DOM.Create("div");
                         help.addCssClass("SWXPopupWindowHelpBox")
                             .addElem('<i class="fa fa-question"></i>');
 
-                        headerDiv.addElem(help);
+                        windowButtons.addElem(help);
                     }
+
+                    if (Module.docker && window._canDock) {
+                        windowButtons.addElem('<span class="SWXPopupWindowDockBox"><i class="fa fa-arrow-circle-left"></i></span>');
+                    }
+
+                    if (window._canClose) {
+                        windowButtons.addElem('<div class="SWXPopupWindowCloseBox"><i class="fa fa-times-circle"></i></div>');
+                    }
+
+                    headerDiv.addElem(windowButtons);
                 }
 
                 var transfer$Elem = null;
@@ -334,12 +347,6 @@ define([
                     DOM.Div({parent: rootDiv}).addCssClass('AXMPopupWindowGripSW GripSW1');
                     DOM.Div({parent: rootDiv}).addCssClass('AXMPopupWindowGripSW GripSW2');
                 }
-
-                if (window._canClose)
-                    rootDiv.addElem('<span class="SWXPopupWindowCloseBox"><i class="fa fa-times-circle"></i></span>');
-
-                if (Module.docker && window._canDock)
-                    rootDiv.addElem('<span class="SWXPopupWindowDockBox"><i class="fa fa-arrow-circle-left"></i></span>');
 
                 $('.AXMContainer').append(rootDiv.toString());
                 window._$ElContainer = $('#' + window._id);

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -274,7 +274,6 @@ define([
                     
                     var titleText = DOM.Div({parent: headerDiv});
                     titleText.addCssClass("PopupHeaderTitleText")
-                        .addStyle("position", "relative")
                         .addStyle("display", "inline-block")
                         .addStyle("overflow-x", "hidden")
                         .addStyle("text-overflow", "ellipsis") 
@@ -437,8 +436,7 @@ define([
                 icon: {
                     get: function getIcon() {
                         var iconContainer = DOM.Create("div");
-                        iconContainer.addCssClass("AXMPopupHeaderIcon")
-                            .addStyle("position", "relative");
+                        iconContainer.addCssClass("AXMPopupHeaderIcon");
                         
                         if (AXMUtils.isObjectType(window._headerIcon, 'icon')) {
                             iconContainer.addElem(window._headerIcon.renderHtml());

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -266,7 +266,6 @@ define([
 
                 if (window._title) {
                     var headerDiv = DOM.Div({parent: rootDiv}).addCssClass('AXMPopupWindowHeader');
-                    headerDiv.addStyle("display", "inline-flex")
                     
                     if (window._headerIcon) {
                         headerDiv.addElem(window.icon);

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -266,33 +266,43 @@ define([
 
                 if (window._title) {
                     var headerDiv = DOM.Div({parent: rootDiv}).addCssClass('AXMPopupWindowHeader');
+                    headerDiv.addStyle("display", "inline-flex")
+                    
                     if (window._headerIcon) {
-                        if (AXMUtils.isObjectType(window._headerIcon, 'icon')) {
-                            var iconDiv = DOM.Div({parent:headerDiv});
-                            iconDiv.addCssClass("AXMPopupHeaderIcon");
-                            iconDiv.addElem(window._headerIcon.renderHtml());
-                        } else {
-                            var str = '<div style="display: inline-block; padding-top:4px;padding-right:16px;vertical-align: top"><i class="AXMPopupHeaderIcon fa {icon}" style=""></i></div>'.AXMInterpolate({icon:window._headerIcon});
-                            headerDiv.addElem(str);
-                        }
+                        headerDiv.addElem(window.icon);
                     }
-
+                    
                     var titleText = DOM.Div({parent: headerDiv});
                     titleText.addCssClass("PopupHeaderTitleText")
+                        .addStyle("position", "relative")
                         .addStyle("display", "inline-block")
-                        .addStyle("margin-right", "20px")
                         .addStyle("overflow-x", "hidden")
                         .addStyle("text-overflow", "ellipsis") 
                         .addStyle("vertical-align", "middle")
                         .addElem(window._title)
 
-                    var labelsContainer = DOM.Create("span");
-                    labelsContainer.addCssClass("AXMPopupLabelsPlaceholder");
-                    // Add labels to popup header as "badges"
-                    window.labels.forEach(function addBadge (badge) {
-                        labelsContainer.addElem(badge);
-                    });
-                    headerDiv.addElem(labelsContainer);
+                    if (window.labels.length > 0) {
+                        var labelsContainer = DOM.Create("div");
+                        labelsContainer.addCssClass("AXMPopupLabelsPlaceholder")
+                            .addStyle("position", "relative");
+
+                        // Add labels to popup header as "badges"
+                        window.labels.forEach(function addBadge (badge) {
+                            labelsContainer.addElem(badge);
+                        });
+                        
+                        headerDiv.addElem(labelsContainer);
+                    }
+
+                    if (window._helpID){
+                        // headerDiv.addElem('<div class="SWXPopupWindowHelpBox" style="position: relative;"><i class="fa fa-question"></i></div>');
+                        var help = DOM.Create("div");
+                        help.addCssClass("SWXPopupWindowHelpBox")
+                            .addStyle("position", "relative")
+                            .addElem('<i class="fa fa-question"></i>');
+
+                        headerDiv.addElem(help);
+                    }
                 }
 
                 var transfer$Elem = null;
@@ -327,9 +337,6 @@ define([
                     DOM.Div({parent: rootDiv}).addCssClass('AXMPopupWindowGripSW GripSW1');
                     DOM.Div({parent: rootDiv}).addCssClass('AXMPopupWindowGripSW GripSW2');
                 }
-
-                if (window._helpID)
-                    rootDiv.addElem('<div class="SWXPopupWindowHelpBox"><i class="fa fa-question"></i></div>');
 
                 if (window._canClose)
                     rootDiv.addElem('<span class="SWXPopupWindowCloseBox"><i class="fa fa-times-circle"></i></span>');
@@ -415,15 +422,33 @@ define([
                 return window._$ElContainer;
             };
 
-            Object.defineProperty(window, 'labels', {
-                get: function getLabels () {
-                    return Object.keys(window._labels).map(function (k) {
-                        var label = window._labels[k];
-                        return DOM.Create("span")
-                            .addCssClass(label.cssClass)
-                            .addCssClass("AXMBadge")
-                            .addElem(label.text);
-                    });
+            Object.defineProperties(window, {
+                labels: {
+                    get: function getLabels () {
+                        return Object.keys(window._labels).map(function (k) {
+                            var label = window._labels[k];
+                            return DOM.Create("span")
+                                .addCssClass(label.cssClass)
+                                .addCssClass("AXMBadge")
+                                .addElem(label.text);
+                        });
+                    }
+                },
+                icon: {
+                    get: function getIcon() {
+                        var iconContainer = DOM.Create("div");
+                        iconContainer.addCssClass("AXMPopupHeaderIcon")
+                            .addStyle("position", "relative");
+                        
+                        if (AXMUtils.isObjectType(window._headerIcon, 'icon')) {
+                            iconContainer.addElem(window._headerIcon.renderHtml());
+                        } else {
+                            var iconElement = '<i class="AXMPopupHeaderIcon fa {icon}" style=""></i>'.AXMInterpolate({icon:window._headerIcon})
+                            iconContainer.addElem(iconElement);
+                        }
+
+                        return iconContainer;
+                    }
                 }
             });
 
@@ -467,6 +492,7 @@ define([
                             .css('left', newPosX)
                             .css('top', newPosY);
                     },
+
                     function() {            // finalise
 
                     }

--- a/Windows/PopupWindow.js
+++ b/Windows/PopupWindow.js
@@ -274,6 +274,7 @@ define([
                     
                     var titleText = DOM.Div({parent: headerDiv});
                     titleText.addCssClass("PopupHeaderTitleText")
+                        .addStyle("margin-right", "8px")
                         .addStyle("display", "inline-block")
                         .addStyle("overflow-x", "hidden")
                         .addStyle("text-overflow", "ellipsis") 
@@ -282,8 +283,7 @@ define([
 
                     if (window.labels.length > 0) {
                         var labelsContainer = DOM.Create("div");
-                        labelsContainer.addCssClass("AXMPopupLabelsPlaceholder")
-                            .addStyle("position", "relative");
+                        labelsContainer.addCssClass("AXMPopupLabelsPlaceholder");
 
                         // Add labels to popup header as "badges"
                         window.labels.forEach(function addBadge (badge) {
@@ -297,7 +297,6 @@ define([
                         // headerDiv.addElem('<div class="SWXPopupWindowHelpBox" style="position: relative;"><i class="fa fa-question"></i></div>');
                         var help = DOM.Create("div");
                         help.addCssClass("SWXPopupWindowHelpBox")
-                            .addStyle("position", "relative")
                             .addElem('<i class="fa fa-question"></i>');
 
                         headerDiv.addElem(help);


### PR DESCRIPTION
Changed header help icon position from absolute (relative to the popup) to relative (within the popup header) and use `margin-left: auto` to right-align it. 

This prevents the help icon from overlapping the header text. Ideally other buttons (close, minimize) should also be positioned this way instead of absolutely?

I had to decrease `padding-right` on the header icon slightly because the header title was not nicely justified for small windows. The `margin-right` that was used before to prevent positioning the help icon on top of the also had the effect of making small popup windows wider artificially. This made the effect of the wide padding on the text less noticeable.