### PR TITLE
Don't close toolbox when clicking overlay from blocking popup

### DIFF
--- a/Panels/Sub/FrameToolBox.js
+++ b/Panels/Sub/FrameToolBox.js
@@ -16,9 +16,9 @@
 
 define([
         "require", "jquery", "_",
-        "AXM/AXMUtils", "AXM/DOM", "AXM/Msg"],
+        "AXM/AXMUtils", "AXM/DOM", "AXM/Msg", "AXM/Windows/SimplePopups"],
     function (require, $, _,
-              AXMUtils, DOM, Msg) {
+              AXMUtils, DOM, Msg, Popup) {
 
 
         /**
@@ -128,6 +128,15 @@ define([
             };
 
             toolBox._onDocClicked = function(ev) {
+                // If a blocking popup is currently active a click event
+                // will originate from the transparant overlay. A user click 
+                // on the overlay will wrongly close the toolbox because
+                // it is not part of the same DOM subtree and thus "outside" 
+                // of the toolbox.
+                if (Popup.currentlyBlocking) {
+                    return;
+                }
+
                 if (ev.target) {
                     var clicked$El = $(ev.target);
                     if (clicked$El.length < 1)

--- a/Windows/SimplePopups.js
+++ b/Windows/SimplePopups.js
@@ -454,6 +454,13 @@ define([
 
         Module.busyWin = null;
 
+        Object.defineProperties(Module, {
+            currentlyBlocking: {
+                get: function() {
+                    return Module.busyWin !== null || Module.blockingBusy_list.length > 0;
+                }
+            }
+        });
 
         /**
          * Displays a busy message that blocks the entire app UI


### PR DESCRIPTION
I encountered this issue intermittently. Toolboxes attach a very broad click event listener to `document`. When an "blocking" overlay is active, click events originate from the overlay. Since the overlay is not in the same DOM sub-tree as the toolbox it causes the toolbox to close even if, from a user perspective, the click originated from _inside_ the toolbox.

Toolboxes won't be closed when the window is blocked.