### PR TITLE
escapeHtml in AXMInterpolate function

### DIFF
--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -233,6 +233,60 @@ define([
         };
 
         /**
+         * Escape html-like characters
+         *
+         * @param  {string} string The string to escape for inserting into HTML
+         * @return {string}
+         * @public
+         */
+        function escapeHtml(string) {
+            var str = '' + string;
+            var match = /["'&<>]/.exec(str);
+
+            if (!match) {
+                return str;
+            }
+
+            var escape;
+            var html = '';
+            var index = 0;
+            var lastIndex = 0;
+
+            for (index = match.index; index < str.length; index++) {
+                switch (str.charCodeAt(index)) {
+                case 34: // "
+                    escape = '&quot;';
+                    break;
+                case 38: // &
+                    escape = '&amp;';
+                    break;
+                case 39: // '
+                    escape = '&#39;';
+                    break;
+                case 60: // <
+                    escape = '&lt;';
+                    break;
+                case 62: // >
+                    escape = '&gt;';
+                    break;
+                default:
+                    continue;
+                }
+
+                if (lastIndex !== index) {
+                    html += str.substring(lastIndex, index);
+                }
+
+                lastIndex = index + 1;
+                html += escape;
+            }
+
+            return lastIndex !== index
+                ? html + str.substring(lastIndex, index)
+                : html;
+        }
+
+        /**
          * Augments the string class with a function that interpolates tokens of the style {token}
          * @param {{}} args - key-value pairs with interpolation tokens
          * @returns {String} - interpolated string
@@ -242,7 +296,7 @@ define([
             var newStr = this;
             for (var key in args) {
                 var regex = new RegExp('{' + key + '}', 'g');
-                 newStr = newStr.replace(regex, args[key]);//keep replacing until all instances of the keys are replaced
+                 newStr = newStr.replace(regex, escapeHtml(args[key]));//keep replacing until all instances of the keys are replaced
             }
             return newStr;
         };

--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -233,11 +233,10 @@ define([
         };
 
         /**
-         * Escape html-like characters
+         * Escape html-like characters in unsafe strings
          *
          * @param  {string} string The string to escape for inserting into HTML
          * @return {string}
-         * @public
          */
         function escapeHtml(string) {
             var str = '' + string;

--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -302,7 +302,7 @@ define([
         function decodeHTML(string) {
             var parser = new DOMParser();
             try {
-                var doc = aparser.parseFromString(string, "text/html");
+                var doc = parser.parseFromString(string, "text/html");
                 return doc.documentElement.textContent;
             } catch (error) {
                 console.error('Error parsing HTML string: "' + error.message + '"');

--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -233,14 +233,15 @@ define([
         };
 
         /**
-         * Escape html-like characters in unsafe strings
+         * The characters `&`, `<`, `>`, `"`, `'`, and `` ` are unsafe for use 
+         * in HTML content, and must be escaped to avoid XSS.
          *
          * @param  {string} string The string to escape for inserting into HTML
          * @return {string}
          */
-        function escapeHtml(string) {
+        function escapeHTML(string) {
             var str = '' + string;
-            var match = /["'&<>]/.exec(str);
+            var match = /["'&<>`]/.exec(str);
 
             if (!match) {
                 return str;
@@ -260,7 +261,7 @@ define([
                     escape = '&amp;';
                     break;
                 case 39: // '
-                    escape = '&#39;';
+                    escape = '&apos;';
                     break;
                 case 60: // <
                     escape = '&lt;';
@@ -268,6 +269,9 @@ define([
                 case 62: // >
                     escape = '&gt;';
                     break;
+                case 96: // ` (backtick)
+                    escape = '&grave;'
+                    break
                 default:
                     continue;
                 }
@@ -295,7 +299,7 @@ define([
             var newStr = this;
             for (var key in args) {
                 var regex = new RegExp('{' + key + '}', 'g');
-                 newStr = newStr.replace(regex, escapeHtml(args[key]));//keep replacing until all instances of the keys are replaced
+                 newStr = newStr.replace(regex, escapeHTML(args[key]));//keep replacing until all instances of the keys are replaced
             }
             return newStr;
         };

--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -290,6 +290,27 @@ define([
         }
 
         /**
+         * Safely parses a string, possibly containing HTML, without running the
+         * risk of executing unwanted JavaScript.
+         * 
+         *  https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
+         *  https://www.w3.org/TR/DOM-Parsing/#widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type
+         * 
+         * @param {string} string 
+         * @returns {string}
+         */
+        function decodeHTML(string) {
+            var parser = new DOMParser();
+            try {
+                var doc = aparser.parseFromString(string, "text/html");
+                return doc.documentElement.textContent;
+            } catch (error) {
+                console.error('Error parsing HTML string: "' + error.message + '"');
+                return string;
+            }
+        }
+
+        /**
          * Augments the string class with a function that interpolates tokens of the style {token}
          * @param {{}} args - key-value pairs with interpolation tokens
          * @returns {String} - interpolated string
@@ -299,7 +320,7 @@ define([
             var newStr = this;
             for (var key in args) {
                 var regex = new RegExp('{' + key + '}', 'g');
-                 newStr = newStr.replace(regex, escapeHTML(args[key]));//keep replacing until all instances of the keys are replaced
+                 newStr = newStr.replace(regex, decodeHTML(escapeHTML(args[key])));//keep replacing until all instances of the keys are replaced
             }
             return newStr;
         };


### PR DESCRIPTION
All of the interpolated values are escaped, but the string literal itself is considered safe. This is often a good assumption when `AXMInterpolate` is used for one-off templates. Possibly breaks stuff, needs testing.
