### PR TITLE
Update scheduler to process in batches

### DIFF
--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -580,9 +580,10 @@ define([
                 }
 
                 // if there are unstarted tasks left (either due to timeout or because their dependencies are not met),
-                // schedule a new processing iteration to run immediately after other processing is done
+                // schedule a new processing iteration to run in the future
+                // wait at least 50ms to avoid high-frequency checking for task dependencies that are still running
                 if (_.any(sched.scheduledFunctions, function(action) { return !action.started; }))
-                    setTimeout(sched._tryNext, 0);
+                    setTimeout(sched._tryNext, 50);
             };
 
             /**


### PR DESCRIPTION
The current implementation of the scheduler runs each job separately with >=50ms in between.
This is not efficient for many small jobs.  For example, during MR AppInit, 20 small tableResources jobs are created resulting in a processing time of 1000ms.

Rather than refactoring these jobs it seems better to improve this at the source:

* One iteration of the scheduler now processes an arbitrary amount of tasks (up to a maximum of ~100ms in running time)
* setTimeout(50) was changed to setTimeout(0).  This avoids the superfluous 50ms of delay between batches.  In principle this schedules the function to run at the earliest convenient time, i.e. after other browser processing has completed.  This should prevent the browser from hanging. (https://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful)