### PR TITLE
Revise scroll event handling

### DIFF
--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -426,7 +426,7 @@ define([
 
             var getOriginalEvent = function(ev) { return ev.originalEvent || ev; };
 
-            var getRawDeltaX = function (ev) { return getOriginalEvent(ev).deltaX / 16; };
+            var getRawDeltaX = function (ev) { return -getOriginalEvent(ev).deltaX / 16; };
             var getRawDeltaY = function(ev) { return -getOriginalEvent(ev).deltaY / 16; };
 
             var getScrollDirection = function(ev) {


### PR DESCRIPTION
Harmonize scroll event handling across browsers with the `wheel` event instead of the deprecated `mousewheel` event.

Tested in FF, Chrome, Safari; could not test yet in IE due to DOMElement issue on master (presumably due to the direct DOM manipulation changes).

Tested using the DataFrame, GenomeBrowser (TrackViewer).  Could not locate an instance of PanelHtml where non-browser scrolling is used.