### PR TITLE
Coerce input to decode to string

### DIFF
--- a/Controls/Controls.js
+++ b/Controls/Controls.js
@@ -1310,7 +1310,7 @@ define([
                     inputEl.addAttribute("type", "password");
                 }
 
-                inputEl.addAttribute("value", he.decode(control._value));
+                inputEl.addAttribute("value", he.decode("" +control._value));
                 if (settings.placeHolder) {
                     inputEl.addAttribute("placeholder", settings.placeHolder);
                 }


### PR DESCRIPTION
`he.decode` doesn't support input of type Number and doesn't coerce implicitly.