### PR TITLE
fix: don't lose context in callback

### DIFF
--- a/Panels/PanelTable.js
+++ b/Panels/PanelTable.js
@@ -442,12 +442,17 @@ define([
              * Sets the html code for the table content
              */
             panel.renderTableContent = function() {
+                if (this) {
+                    panel = this;
+                }
+
                 panel._tableRowCount = panel._tableData.getRowCount();
                 var rowFirst = panel._tableOffset;
                 var rowLast = Math.min(panel._tableRowCount-1, panel._tableOffset+panel._tableLineCount-1);
 
-                if (!panel._tableData.requireRowRange(rowFirst, rowLast, panel.renderTableContent, panel.renderFail))
+                if (!panel._tableData.requireRowRange(rowFirst, rowLast, panel.renderTableContent.bind(panel), panel.renderFail)) {
                     return;
+                }
 
                 var $ElRightBody = $('#'+panel._divid_rightBody);
                 var $ElLeftBody = $('#'+panel._divid_leftBody);
@@ -748,7 +753,7 @@ define([
                 var rowLast = Math.min(panel._tableRowCount-1, panel._tableOffset+panel._tableLineCount-1);
                 diff = panel._tableOffset - tableOffsetPrev; // Corrected difference
 
-                if (!panel._tableData.requireRowRange(rowFirst, rowLast, panel.renderTableContent, panel.renderFail))
+                if (!panel._tableData.requireRowRange(rowFirst, rowLast, panel.renderTableContent.bind(this), panel.renderFail))
                     return; // We need to fetch data first - no fast update here - full rendering will happen
 
                 if (diff > 0) {

--- a/Panels/PanelTable.js
+++ b/Panels/PanelTable.js
@@ -753,7 +753,7 @@ define([
                 var rowLast = Math.min(panel._tableRowCount-1, panel._tableOffset+panel._tableLineCount-1);
                 diff = panel._tableOffset - tableOffsetPrev; // Corrected difference
 
-                if (!panel._tableData.requireRowRange(rowFirst, rowLast, panel.renderTableContent.bind(this), panel.renderFail))
+                if (!panel._tableData.requireRowRange(rowFirst, rowLast, panel.renderTableContent.bind(panel), panel.renderFail))
                     return; // We need to fetch data first - no fast update here - full rendering will happen
 
                 if (diff > 0) {


### PR DESCRIPTION
**Context**
This issue has been around for a long time
https://sentry.prd-15.aws.agilent.com/multiplicom/mastr-reporter-dev/issues/6527/ (Aug 2019)
https://sentry.prd-15.aws.agilent.com/multiplicom/mastr-reporter-production/issues/5015/ (Nov 2018)
https://sentry.prd-15.aws.agilent.com/multiplicom/mastr-reporter-dev/issues/725/ (Dec 2017)
https://sentry.prd-15.aws.agilent.com/multiplicom/mastr-reporter-dev/issues/108/ (Apr 2017)

**Comments**
If renderTableContent is called from a call back, the context is lost and panel variable isn't bound. The typical solution is to use `Function.prototype.bind` on the callback, but this can only re-bind `this`.

I agree the solution is a bit funky, but has to do with the fact that these "classes" have been written using the "module" pattern to explicitly eschew`this`. If you figure out a better way, let me know.
