### PR TITLE
Don't preventDefault by... default

### DIFF
--- a/Controls/Clickable.js
+++ b/Controls/Clickable.js
@@ -9,9 +9,11 @@ define(["require"], function() {
             this._getSub$El("").click(
                 function onControlClicked(event) {
                     if (this) {
-                        this.performNotify();
+                        this.performNotify(event);
                         event.stopPropagation();
-                        return false;
+                        // Don't return false, callback can 
+                        // use Event.preventDefault instead 
+                        // choose the behavior it likes.
                     }
                 }.bind(this) 
             );

--- a/Controls/Controls.js
+++ b/Controls/Controls.js
@@ -57,18 +57,6 @@ define([
                 height: "21px"
             };
 
-            this.handlers = Object.keys(this.props).reduce(
-                function getEventListeners(handlers, propName) {
-                    if (propName.slice(0, 2) === "on") {
-                        handlers[propName] = props[propName];
-                    }
-
-                    return handlers;
-                },
-                {},
-                this
-            );
-
             this.createHtml = function createHTML() {
                 return DOM.Div(
                     $.extend(this.handlers, {


### PR DESCRIPTION
I made a change. Previously, `Clickable` always prevented default by doing `return false`, instead the event is now passed along to the callback. The callback can then decide if it wants to prevent the default behaviour or not by doing `Event.preventDefault()`. 

A minimal example of the control:

```javascript
define(["require", "AXM/Controls", "AXM/Controls/Clickable"], function(
    require
) {
    "use strict";

    var Clickable = require("AXM/Controls/Clickable");
    var Controls = require("AXM/Controls/Controls");
    var Toggle = Controls.Toggle;

    // Clickable mixin
    // See: https://javascript.info/mixins
    Object.assign(Toggle.prototype, Clickable);

    var toggle = new Toggle();
    toggle.addNotificationHandler(
        // Handle the click event
        function onStateChange(event) {
            console.log(`Value was ${this.value}, changing to ${!this.value}`);
            this.value = !this.value;
        }.bind(toggle)
    );
});
```