### PR TITLE
prevent default allows control zoom

### DIFF
--- a/Panels/PanelCanvasZoomPan.js
+++ b/Panels/PanelCanvasZoomPan.js
@@ -798,7 +798,7 @@ define([
             panel.attachEventHandlers = function() {
                 _super_attachEventHandlers();
                 var clickLayer$El = panel.getCanvas$El('selection');
-                AXMUtils.create$ElScrollHandler(clickLayer$El, panel._handleScrolled);
+                AXMUtils.create$ElScrollHandler(clickLayer$El, panel._handleScrolled, true);
                 AXMUtils.create$ElDragHandler(clickLayer$El, panel._panningStart, panel._panningDo, panel._panningStop);
                 clickLayer$El.mousemove(panel._onMouseMove);
                 clickLayer$El.click(panel._onClick);


### PR DESCRIPTION
Add preventDefault to the scroll handler in PanelCanvasZoomPan panels (XY plots, bar graph and other implementations). 

Case: if not zooming simultaneously, but only using the controlPressed option, there was a conflict with the default behaviour on Windows PCs: Control+MouseScrollWheel zooms in the browser.

This change prevents the default behaviour inside the canvas element.

The solution is identical to what is present for FrameTrackViewer

Reviewers: can you think of any behaviour that might get broken? Please review ASAP.