### PR TITLE
set prop value instead of removing fixes #76

### DIFF
--- a/Controls/Controls.js
+++ b/Controls/Controls.js
@@ -791,7 +791,7 @@ define([
                 if (newVal == control.getValue()) return false;
                 control._value = newVal;
                 if (control._value) control._getSub$El("").prop("checked", "checked");
-                else control._getSub$El("").removeProp("checked");
+                else control._getSub$El("").prop("checked", "");
                 if (!preventNotify) control.performNotify();
                 control._checkCheckedClass();
                 return true;


### PR DESCRIPTION
To disable the checkbox, the remove prop function was used, but this should not be used on native properties. The canonical way is to set these properties to false values. Used empty string to be consistent with initiation in method above.
https://api.jquery.com/removeprop/ 

