### PR TITLE
Add option to droplist control to add a blank state only if there is more than 1 option

### DIFF
--- a/Controls/Controls.js
+++ b/Controls/Controls.js
@@ -818,6 +818,10 @@ define([
          * @param {int} settings.height - height of the box
          * @param {int} settings.value - initial state id
          * @param {boolean} settings.disabled - if true, the control is disabled
+         * @param {boolean} settings.autoBlankOption - provide an option with ID equal to empty string
+         * if there is more than 1 state. Omitted if there is only 1 state.
+         * @param {string} settings.autoBlankOptionName - set the display name for the option above. If specified,
+         * the autoBlankOption is considered to be true
          * @returns {Object} - control instance
          * @constructor
          */
@@ -829,7 +833,8 @@ define([
             control._value = settings.value || '';
             control._disabled = settings.disabled || false;
             control._title = settings.title || '';
-
+            control._autoBlankState = !!settings.autoBlankOption || settings.autoBlankOptionName;
+            control._autoBlankStateName = settings.autoBlankOptionName || _TRL('-- Select --');
 
             /**
              * Removes all the states from the list
@@ -892,6 +897,10 @@ define([
             control._buildSelectContent = function() {
                 var st = '';
                 var lastGroupName = '';
+                let blankUsed = control._states.map((state) => state.id).includes('');
+                if(control._states.length > 1 && control._autoBlankState && !blankUsed){
+                    st += `<option value="" ${('' == control._value) ? 'selected="selected"' : ''}>${control._autoBlankStateName}</option>`;
+                }
                 $.each(control._states, function(idx, state) {
                     var groupName = state.group || '';
                     if (groupName != lastGroupName) {


### PR DESCRIPTION
Adds a settings option to the Droplist control to add a blank state with the default name "-- Select --" to the Droplist only if there is more than 1 option available. There is a second option to change this default name of the blank option.

Closes #78 

To reviewers: would it make sense to also add this option only in case the initial value of the droplist is not part of the selected states (e.g. the DropList has been created without an initial selected value or the initial selected value is not known? 
* Pro: 1 fewer option and forces the user to pick something
* Con: forces the user to pick something when they maybe want to wait with picking an option
* Con: in cases the user had no default, then picks a value and the droplist gets updated by an external action, the droplist will likely change content (i.e. the blank state will be removed) causing possible confusion at user's end.