### PR TITLE
fix auto closing tags #87

### DIFF
--- a/Panels/PanelTable.js
+++ b/Panels/PanelTable.js
@@ -346,7 +346,7 @@ define([
                 if (colInfo.isOpener) {
                     var cell = `<div class="AXMPgTableLinkCell" title="${_TRL('Open this item')}">`;
                     cell += '<div class="AXMPgTableLinkIcon"><i class="fa fa-external-link-square"></i></div>';
-                    cell += '<div style="display:inline-block;height:100%;width:1px;vertical-align:middle"/>';
+                    cell += '<div style="display:inline-block;height:100%;width:1px;vertical-align:middle"></div>';
                     cell += '</div>';
                     return cell;
                 }
@@ -357,7 +357,7 @@ define([
                         cell += '<div class="AXMPgTableSelectorIcon"><i class="fa fa-circle-thin"></i></div>';
                     else
                         cell += '<div class="AXMPgTableSelectorIconActive"><i class="fa fa-check-circle"></i></div>';
-                    cell += '<div style="display:inline-block;height:100%;width:1px;vertical-align:middle"/>';
+                    cell += '<div style="display:inline-block;height:100%;width:1px;vertical-align:middle"></div>';
                     cell += '</div>';
                     return cell;
                 }

--- a/Windows/DocViewer.js
+++ b/Windows/DocViewer.js
@@ -39,7 +39,7 @@ define([
                 .done(function (data) {
                     if (busyid)
                         SimplePopups.stopBlockingBusy(busyid);
-                    var content = $('<div/>').append(data).find('.AXMDocContent').html();
+                    var content = $('<div></div>').append(data).find('.AXMDocContent').html();
                     content = _TRL(content);
                     onCompleted(content);
                 })
@@ -167,7 +167,7 @@ define([
                 $.get(url, {})
                     .done(function (data) {
                         SimplePopups.stopBlockingBusy(busyid);
-                        var content = $('<div/>').append(data).find('.AXMDocContent').html();
+                        var content = $('<div></div>').append(data).find('.AXMDocContent').html();
                         content = _TRL(content);
                         win._loadContent('<div class="AXMDocContent">' + content + '</div>', scrollPos);
                     })

--- a/Windows/SimplePopups.js
+++ b/Windows/SimplePopups.js
@@ -53,8 +53,8 @@ define([
                     onProceed();
             };
 
-            var grp = Controls.Compound.GroupVert({});
-            grp.add(Controls.Static({text: typeof content === "object" ? content : content +'<p/>'}));
+            var grp = Controls.Compound.GroupVert({separator: 12});
+            grp.add(Controls.Static({text: content}));
 
             var btOK = Controls.Button({
                 text: _TRL('OK'),
@@ -98,8 +98,8 @@ define([
                 autoCenter: true
             });
 
-            var grp = Controls.Compound.GroupVert({});
-            grp.add(Controls.Static({text: typeof content === "object" ? content : content +'<p/>'}));
+            var grp = Controls.Compound.GroupVert({separator: 12});
+            grp.add(Controls.Static({text: content}));
 
             var btOK = Controls.Button({
                 text: settings.textOK || _TRL('OK'),
@@ -158,8 +158,8 @@ define([
                 autoCenter: true
             });
 
-            var grp = Controls.Compound.GroupVert({});
-            grp.add(Controls.Static({text: typeof content === "object" ? content : content +'<p/>'}));
+            var grp = Controls.Compound.GroupVert({separator: 12});
+            grp.add(Controls.Static({text: content}));
 
             var btYes = Controls.Button({
                 text: settings.textYes || _TRL('Yes'),
@@ -221,8 +221,8 @@ define([
                 autoCenter: true
             });
 
-            var grp = Controls.Compound.GroupVert({});
-            grp.add(Controls.Static({text: typeof intro === "object" ? intro : intro +'<p/>'}));
+            var grp = Controls.Compound.GroupVert({separator: 12});
+            grp.add(Controls.Static({text: intro}));
 
             var buttons = [];
             $.each(actions, function(idx, action) {
@@ -442,10 +442,10 @@ define([
                 })
             );
 
-            var grp2 = Controls.Compound.GroupVert({});
+            var grp2 = Controls.Compound.GroupVert({separator: 12});
             grp1.add(grp2);
             grp2.add(
-                Controls.Static({ text: typeof content === "object" ? content : content + "<p/>" })
+                Controls.Static({ text: content })
             );
 
             var btOK = Controls.Button({


### PR DESCRIPTION
Related to issue #87 

Changes: 
- PanelTable: change auto-closing div to open-close. Did not seem to be an issue, but jQuery auto resolved this situation to the one now being used.
- DocViewer: given the find method, it does not matter whether an auto-closing was used (will resolve). But changed in order to be correct.
- SimplePopups: jQuery correctly resolved all cases to a single paragraph: `<p/>` was resolved to `<p></p>`, but given that it seemed unsafe, I modified the behaviour. Previous behaviour was to add vertical spacing between the text and the buttons. I don't know if it had another effect so not sure if my change results in the same behaviour as before.

Tested manually and everything looks fine (but did not check all possible cases for the simplePopups).

