### PR TITLE
Set default left track offset to 0px (#100).

### DIFF
--- a/Panels/FrameTrackViewer.js
+++ b/Panels/FrameTrackViewer.js
@@ -31,7 +31,7 @@ define([
          */
         var Module = {};
 
-        Module._trackOffsetLeft = 20;
+        Module._trackOffsetLeft = 0;
         Module._trackOffsetRight = 0;
         Module._leftRightOffsetMarginH = 1;
         Module._trackMarginV = 2;


### PR DESCRIPTION
Set the default left track offset to 0px in the genome browser, see #100 for details.