### PR TITLE
Update popupwindow MultipleChoiceBox to show help button next to titl…

### DIFF
--- a/Windows/SimplePopups.js
+++ b/Windows/SimplePopups.js
@@ -341,16 +341,29 @@ define([
 
             var grp = Controls.Compound.GroupVert({separator:5});
 
-            if (settings.useTransientPopup && (!header) && title)
-                grp.add(title);
-
-            if (settings.helpId)
+            let addElementWithHelpId = function(element, helpId){
                 grp.add(Controls.Compound.GroupHor({verticalAlignCenter: true}, [
-                    header,
-                    Controls.HelpButton(settings.helpId)
+                    element,
+                    Controls.HelpButton(helpId)
                 ]) );
-            else
-                grp.add(header);
+            };
+
+            if (settings.useTransientPopup && (!header) && title){
+                if(settings.helpId){
+                    addElementWithHelpId(title, settings.helpId);
+                }
+                else{
+                    grp.add(title);
+                }
+            }
+            else{
+                if (settings.helpId){
+                    addElementWithHelpId(header, settings.helpId);
+                }
+                else{
+                    grp.add(header);
+                }
+            }
 
             var btOK = Controls.Button({
                 text: _TRL('OK'),


### PR DESCRIPTION
closes #103 

Update to place help button on same line as title in case a title has been provided, but no header. When a header is provided, the help button will be placed next to the header.

I checked that the appearance of a Multiple choice popup is not affected when not providing a helpId.

New:
<img width="462" alt="Screenshot 2021-05-06 at 11 20 30" src="https://user-images.githubusercontent.com/77333047/117274151-13a98380-ae5d-11eb-97bf-dc1ca67ea13b.png">

Not affected:
<img width="455" alt="Screenshot 2021-05-06 at 11 20 58" src="https://user-images.githubusercontent.com/77333047/117274208-23c16300-ae5d-11eb-91e0-d7e2294f93b4.png">
<img width="416" alt="Screenshot 2021-05-06 at 11 21 14" src="https://user-images.githubusercontent.com/77333047/117274243-2cb23480-ae5d-11eb-9b55-387d01174d88.png">
