### PR TITLE
Fix for #119.

### DIFF
--- a/Panels/FrameTrackViewer.js
+++ b/Panels/FrameTrackViewer.js
@@ -1108,6 +1108,7 @@ define([
             var thePanel = Module.PanelTrackViewer();
             var theFrame = Frame.FrameFinalCommands(thePanel);
 
+            theFrame.includesToolBox = true;
             theFrame.trackControlsGroup = Controls.Compound.GroupVert({separator: 3});
             theFrame._popupMenuExtraControlsGroup = Controls.Compound.GroupVert({separator: 3});
 


### PR DESCRIPTION
Bug fix for the currently not shown show/hide checkboxes in the toolbox menu of the FrameTrackViewer.