### PR TITLE
Also allow :, notation when interpolating string for snippets.

### DIFF
--- a/AXMUtils.js
+++ b/AXMUtils.js
@@ -239,9 +239,17 @@ define([
          */
         String.prototype.AXMInterpolate = function (args) {
             var newStr = this;
+            const replacer = function(match){
+                if(match.includes(':,')){
+                    return args[key].toLocaleString('en-US');
+                }
+                else{
+                    return args[key];
+                }
+            };
             for (var key in args) {
-                var regex = new RegExp('{' + key + '}', 'g');
-                 newStr = newStr.replace(regex, args[key]);//keep replacing until all instances of the keys are replaced
+                var regex = new RegExp('{' + key + ':,}|{' + key + '}', 'g');
+                newStr = newStr.replace(regex, replacer);//keep replacing until all instances of the keys are replaced
             }
             return newStr;
         };
@@ -868,4 +876,3 @@ define([
 
         return Module;
     });
-


### PR DESCRIPTION
Currently always format numbers as 'en-US' and not via the client locale's formatting when :, is part of the interpolation string.

formatting as en-US does more then only adding comma's, like automatically using a dot as decimal separator. This is however exactly what we want.