### PR TITLE
Add liveUpdate function to GroupHor compound control (#122).

### DIFF
--- a/Controls/Compound.js
+++ b/Controls/Compound.js
@@ -227,7 +227,7 @@ define(["require", "jquery", "_", "AXM/AXMUtils", "AXM/DOM", "AXM/Units"],
              * @returns {string}
              */
             compound.render = function() {
-                var div = DOM.Div();
+                var div = DOM.Div({ id: compound._id + "_wrapper"});
                 if (compound._noWrap)
                     div.addStyle('white-space', 'nowrap');
                 var maxElem = compound._members.length - 1;
@@ -245,6 +245,22 @@ define(["require", "jquery", "_", "AXM/AXMUtils", "AXM/DOM", "AXM/Units"],
                     elemDiv.addElem(member.render());
                 });
                 return div;
+            };
+
+            compound.liveUpdate = function() {
+                var el = document.getElementById(compound._id + "_wrapper");
+
+                if (el) {
+                    el.innerHTML = '';
+
+                    var updatedControl = compound.render();
+                    var documentFragment = document.createDocumentFragment();
+                    documentFragment.appendChild(updatedControl.node$);
+
+                    el.appendChild(documentFragment);
+                }
+
+                compound.attachEventHandlers();
             };
 
             return compound;


### PR DESCRIPTION
Added the exact same live update functionality as in `GroupVert` to the `GroupHor` compound control.

By now, all `CompoundControlBase` implementations (`GroupHor`, `GroupVert`, `Grid`, `ColorLegend`) include a similar liveUpdate function. It is probably possible to refactor this to a shared liveUpdate function in `CompoundControlBase`, but that would be a change that requires a lot of testing. I therefore decided not to refactor this and to only add the function to `GroupHor`.