### PR TITLE
switch to json stringify #126

### DIFF
--- a/Panels/PanelTable.js
+++ b/Panels/PanelTable.js
@@ -810,7 +810,11 @@ define([
                         if (colInfo.getName().length > 0) {
                             if (line.length > 0)
                                 line += '\t';
-                            line += colInfo.content2DisplayString(rowData[colInfo.getId()], rowData);
+                            const content = colInfo.content2DisplayString(rowData[colInfo.getId()], rowData);
+
+                            // escape characters such as line feeds for TSV files,
+                            // but remove the begin and end quotes added by JSON stringify
+                            line += JSON.stringify(content).slice(1, -1);
                         }
                     });
                     data += line + '\n';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agilent/axiom",
-  "version": "1.5.0",
+  "version": "1.5.3",
   "main": "index.js",
   "repository": "git@github.com:Multiplicom/axiom.git",
   "author": "Agilent Genomics SW team <pdl-gsst-gnt-software@agilent.com>",


### PR DESCRIPTION
replace TSV-specific characters in the content with escaped versions using JSON stringify and remove the begin and end quotes from this:

![Screenshot 2022-05-17 at 17 25 23](https://user-images.githubusercontent.com/8429157/168848745-0f336f65-102a-4bb5-bae5-28046bd192fe.png)

Tested manually with content containing newlines. Before the change, any text editor used the newlines, but using the escape the characters where visible but not used. Alternatively I could just remove them if that is more appropriate.

Advantage of escaping is that it still shows the original content, but it might still confuse naive parsers...

Note: according to the standard, https://tc39.es/ecma262/multipage/structured-data.html#sec-json.stringify in addition to newlines and tabs, `JSON.stringify` also escapes quotes. These don't show up in text editors. Effect on TSV parsers unknown.

This is a change from #127 using JSON stringify